### PR TITLE
Update watch app for watchOS 11 APIs

### DIFF
--- a/DiaBLE Watch Extension/Views/Console.swift
+++ b/DiaBLE Watch Extension/Views/Console.swift
@@ -174,7 +174,7 @@ struct Console: View {
 
             }.font(.footnote)
         }
-        .edgesIgnoringSafeArea(.bottom)
+        .ignoresSafeArea(.container, edges: .bottom)
         .navigationTitle("Console")
     }
 }

--- a/DiaBLE Watch Extension/Views/ContentView.swift
+++ b/DiaBLE Watch Extension/Views/ContentView.swift
@@ -11,7 +11,7 @@ struct ContentView: View {
     @State var isMonitorActive = false
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: -4) {
                     HStack(spacing: 10) {
@@ -62,7 +62,7 @@ struct ContentView: View {
             }
             .navigationTitle("DiaBLE  \(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String)")
         }
-        .edgesIgnoringSafeArea([.bottom])
+        .ignoresSafeArea(.container, edges: .bottom)
     }
 }
 

--- a/DiaBLE Watch Extension/Views/DataView.swift
+++ b/DiaBLE Watch Extension/Views/DataView.swift
@@ -174,7 +174,7 @@ struct DataView: View {
 
         }
         .navigationTitle("Data")
-        .edgesIgnoringSafeArea([.bottom])
+        .ignoresSafeArea(.container, edges: .bottom)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         // .font(.system(.footnote, design: .monospaced)).foregroundColor(Color(.lightGray))
         .font(.footnote)

--- a/DiaBLE Watch Extension/Views/Details.swift
+++ b/DiaBLE Watch Extension/Views/Details.swift
@@ -281,7 +281,10 @@ struct Details: View {
 
                 Spacer()
 
-            }.edgesIgnoringSafeArea(.bottom).padding(.vertical, -40).offset(y: 40)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
+            .padding(.vertical, -40)
+            .offset(y: 40)
 
         }
         .navigationTitle("Details")
@@ -303,7 +306,7 @@ struct Details_Preview: PreviewProvider {
             Details()
                 .environmentObject(AppState.test(tab: .monitor))
                 .environmentObject(Settings())
-            NavigationView {
+            NavigationStack {
                 Details()
                     .environmentObject(AppState.test(tab: .monitor))
                     .environmentObject(Settings())

--- a/DiaBLE Watch Extension/Views/Monitor.swift
+++ b/DiaBLE Watch Extension/Views/Monitor.swift
@@ -186,7 +186,7 @@ struct Monitor: View {
         }
         // .navigationTitle("Monitor")
         .navigationBarHidden(true)
-        .edgesIgnoringSafeArea([.top, .bottom])
+        .ignoresSafeArea(.container, edges: [.top, .bottom])
         .buttonStyle(.plain)
         .multilineTextAlignment(.center)
         .onAppear {

--- a/DiaBLE Watch Extension/Views/OnlineView.swift
+++ b/DiaBLE Watch Extension/Views/OnlineView.swift
@@ -67,7 +67,7 @@ struct OnlineView: View {
             } }
         }
         .navigationTitle("Online")
-        .edgesIgnoringSafeArea([.bottom])
+        .ignoresSafeArea(.container, edges: .bottom)
         .buttonStyle(.plain)
         .foregroundColor(.cyan)
 

--- a/DiaBLE Watch Extension/Views/SettingsView.swift
+++ b/DiaBLE Watch Extension/Views/SettingsView.swift
@@ -139,7 +139,7 @@ struct SettingsView: View {
             }.padding(.top, 6)
 
         }
-        .edgesIgnoringSafeArea([.top, .bottom])
+        .ignoresSafeArea(.container, edges: [.top, .bottom])
         .navigationTitle("Settings")
         .font(Font.body.monospacedDigit())
         .buttonStyle(.plain)

--- a/DiaBLE.xcodeproj/project.pbxproj
+++ b/DiaBLE.xcodeproj/project.pbxproj
@@ -642,7 +642,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.0;
+                            WATCHOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -663,7 +663,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.0;
+                            WATCHOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};
@@ -690,7 +690,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.0;
+                            WATCHOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Debug;
 		};
@@ -717,7 +717,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 8.0;
+                            WATCHOS_DEPLOYMENT_TARGET = 11.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Summary
- raise the watch extension deployment target to watchOS 11
- migrate watch views to NavigationStack and ignoresSafeArea for modern SwiftUI
- refresh safe-area handling across watch views for the newer watchOS layout system

## Testing
- not run (watchOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1300e148c83298d65a7f08573636e